### PR TITLE
magefile.goで.envの環境変数を取得するように修正

### DIFF
--- a/config/db_config.go
+++ b/config/db_config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // loadDataSourceNameはデータベースの設定を読み込み、データベースの接続文字列（DSN）を返す
-func loadDataSourceName() (string, error) {
+func LoadDataSourceName() (string, error) {
 	// 環境変数から設定を読み込み
 	dbUser := os.Getenv("POSTGRES_USER")
 	dbPassword := os.Getenv("POSTGRES_PASSWORD")
@@ -34,7 +34,7 @@ func loadDataSourceName() (string, error) {
 
 func NewDatabase() (*bun.DB, error) {
 	// データベース接続文字列（DSN）を取得
-	dbDsn, err := loadDataSourceName()
+	dbDsn, err := LoadDataSourceName()
 	if err != nil {
 		return nil, fmt.Errorf("failed to loadDataSourceName: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.4
 
 require (
 	github.com/jackc/pgx/v5 v5.7.1
+	github.com/joho/godotenv v1.5.1
 	github.com/rs/cors v1.11.1
 	github.com/uptrace/bun v1.2.6
 	github.com/uptrace/bun/dialect/pgdialect v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=

--- a/magefile.go
+++ b/magefile.go
@@ -6,6 +6,9 @@ package main
 import (
 	"fmt"
 	"os/exec"
+
+	"github.com/AuroralTech/todo-api_202412/config"
+	"github.com/joho/godotenv"
 )
 
 var Aliases = map[string]interface{}{
@@ -18,19 +21,34 @@ var Aliases = map[string]interface{}{
 func MigrationUp(arg string) error {
 	fmt.Println("マイグレーションを開始します...")
 
+	// .envファイルを読み込む
+	if err := godotenv.Load(".env"); err != nil {
+		fmt.Println(".envファイルを読み込めませんでした")
+		return err
+	}
+	// データベース接続文字列（DSN）を取得
+	dbDsn, err := config.LoadDataSourceName()
+	if err != nil {
+		fmt.Println("データベース接続文字列を取得できませんでした")
+		return err
+	}
+
 	var cmd []byte
-	var err error
 
 	if arg == "all" {
 		// 全てのマイグレーションを実行
-		cmd, err = exec.Command("docker", "compose", "run", "--rm", "migrate",
-			"-database", "postgres://root:password@db/local_db?sslmode=disable",
-			"-path", "db/migrations", "up").CombinedOutput()
+		cmd, err = exec.Command(
+			"docker", "compose", "run", "--rm", "migrate",
+			"-database", dbDsn,
+			"-path", "db/migrations", "up",
+		).CombinedOutput()
 	} else {
 		// 引数がある場合は指定された数のマイグレーションのみ実行
-		cmd, err = exec.Command("docker", "compose", "run", "--rm", "migrate",
-			"-database", "postgres://root:password@db/local_db?sslmode=disable",
-			"-path", "db/migrations", "up", arg).CombinedOutput()
+		cmd, err = exec.Command(
+			"docker", "compose", "run", "--rm", "migrate",
+			"-database", dbDsn,
+			"-path", "db/migrations", "up", arg,
+		).CombinedOutput()
 	}
 
 	fmt.Println("Output Command:", string(cmd))
@@ -47,19 +65,34 @@ func MigrationUp(arg string) error {
 func MigrationDown(arg string) error {
 	fmt.Println("マイグレーションを開始します...")
 
+	// .envファイルを読み込む
+	if err := godotenv.Load(".env"); err != nil {
+		fmt.Println(".envファイルを読み込めませんでした")
+		return err
+	}
+	// データベース接続文字列（DSN）を取得
+	dbDsn, err := config.LoadDataSourceName()
+	if err != nil {
+		fmt.Println("データベース接続文字列を取得できませんでした")
+		return err
+	}
+
 	var cmd []byte
-	var err error
 
 	if arg == "all" {
 		// 全てのマイグレーションを実行
-		cmd, err = exec.Command("docker", "compose", "run", "--rm", "migrate",
-			"-database", "postgres://root:password@db/local_db?sslmode=disable",
-			"-path", "db/migrations", "down").CombinedOutput()
+		cmd, err = exec.Command(
+			"docker", "compose", "run", "--rm", "migrate",
+			"-database", dbDsn,
+			"-path", "db/migrations", "down", "-all",
+		).CombinedOutput()
 	} else {
 		// 引数がある場合は指定された数のマイグレーションのみ実行
-		cmd, err = exec.Command("docker", "compose", "run", "--rm", "migrate",
-			"-database", "postgres://root:password@db/local_db?sslmode=disable",
-			"-path", "db/migrations", "down", arg).CombinedOutput()
+		cmd, err = exec.Command(
+			"docker", "compose", "run", "--rm", "migrate",
+			"-database", dbDsn,
+			"-path", "db/migrations", "down", arg,
+		).CombinedOutput()
 	}
 
 	fmt.Println("Output Command:", string(cmd))


### PR DESCRIPTION
## やったこと

1. magefile.goで.envの環境変数を取得するように修正 しました。
2. マイグレーションのdown allがエラーになるため`-allフラグ`を追加して動作するように修正しました。


## 動作確認

- マイグレーション（ up all ）

```
% mage mup all          
                                      
マイグレーションを開始します...
Output Command: time="2024-12-16T19:54:10+09:00" level=warning msg="/Users/fukutaniyuta/dev/todo-api_202412/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
 Container todo-api_202412-db-1  Running
20241215125616/u create_users (3.648167ms)

マイグレーションが完了しました!!
```

- マイグレーション（ down all ）

```
% mage mdown all                                              

マイグレーションを開始します...
Output Command: time="2024-12-16T19:55:04+09:00" level=warning msg="/Users/fukutaniyuta/dev/todo-api_202412/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
 Container todo-api_202412-db-1  Running
20241215125616/d create_users (3.035667ms)

マイグレーションが完了しました!!
```


